### PR TITLE
feat: Add URL redirect for old multilingual URLs

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,40 @@
+{{- define "main" }}
+<div class="not-found">404</div>
+<script>
+(function() {
+  var path = window.location.pathname;
+  var search = window.location.search;
+  var hash = window.location.hash;
+  
+  // Skip if already has language prefix
+  if (path.match(/^\/(ko|en)(\/|$)/)) {
+    return;
+  }
+  
+  // Patterns to redirect (with or without trailing slash)
+  var patterns = ['posts', 'about', 'tags', 'search'];
+  var shouldRedirect = patterns.some(function(p) {
+    return path === '/' + p || path === '/' + p + '/' || path.indexOf('/' + p + '/') === 0;
+  });
+  
+  if (!shouldRedirect) {
+    return;
+  }
+  
+  // Normalize path with trailing slash
+  if (!path.endsWith('/')) {
+    path = path + '/';
+  }
+  
+  // Detect language
+  var lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
+  var prefix = lang.indexOf('ko') === 0 ? '/ko' : '/en';
+  
+  // Redirect with query and hash preserved
+  window.location.replace(prefix + path + search + hash);
+})();
+</script>
+<noscript>
+  <p style="text-align: center; margin-top: 1rem;">The page you're looking for doesn't exist.</p>
+</noscript>
+{{- end }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,39 +1,6 @@
 {{- define "main" }}
 <div class="not-found">404</div>
-<script>
-(function() {
-  var path = window.location.pathname;
-  var search = window.location.search;
-  var hash = window.location.hash;
-  
-  // Skip if already has language prefix
-  if (path.match(/^\/(ko|en)(\/|$)/)) {
-    return;
-  }
-  
-  // Patterns to redirect (with or without trailing slash)
-  var patterns = ['posts', 'about', 'tags', 'search'];
-  var shouldRedirect = patterns.some(function(p) {
-    return path === '/' + p || path === '/' + p + '/' || path.indexOf('/' + p + '/') === 0;
-  });
-  
-  if (!shouldRedirect) {
-    return;
-  }
-  
-  // Normalize path with trailing slash
-  if (!path.endsWith('/')) {
-    path = path + '/';
-  }
-  
-  // Detect language
-  var lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
-  var prefix = lang.indexOf('ko') === 0 ? '/ko' : '/en';
-  
-  // Redirect with query and hash preserved
-  window.location.replace(prefix + path + search + hash);
-})();
-</script>
+<script src="/js/404-redirect.js"></script>
 <noscript>
   <p style="text-align: center; margin-top: 1rem;">The page you're looking for doesn't exist.</p>
 </noscript>

--- a/static/404.html
+++ b/static/404.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - Page Not Found</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; text-align: center; padding: 2rem; }
+        .not-found { font-size: 8rem; font-weight: bold; color: #666; }
+    </style>
+</head>
+<body>
+<div class="not-found">404</div>
+<script>
+(function() {
+  var path = window.location.pathname;
+  var search = window.location.search;
+  var hash = window.location.hash;
+  
+  if (path.match(/^\/(ko|en)(\/|$)/)) {
+    return;
+  }
+  
+  var patterns = ['posts', 'about', 'tags', 'search'];
+  var shouldRedirect = patterns.some(function(p) {
+    return path === '/' + p || path === '/' + p + '/' || path.indexOf('/' + p + '/') === 0;
+  });
+  
+  if (!shouldRedirect) {
+    return;
+  }
+  
+  if (!path.endsWith('/')) {
+    path = path + '/';
+  }
+  
+  var lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
+  var prefix = lang.indexOf('ko') === 0 ? '/ko' : '/en';
+  
+  window.location.replace(prefix + path + search + hash);
+})();
+</script>
+<noscript>
+  <p style="text-align: center; margin-top: 1rem;">The page you're looking for doesn't exist.</p>
+</noscript>
+</body>
+</html>

--- a/static/404.html
+++ b/static/404.html
@@ -11,35 +11,7 @@
 </head>
 <body>
 <div class="not-found">404</div>
-<script>
-(function() {
-  var path = window.location.pathname;
-  var search = window.location.search;
-  var hash = window.location.hash;
-  
-  if (path.match(/^\/(ko|en)(\/|$)/)) {
-    return;
-  }
-  
-  var patterns = ['posts', 'about', 'tags', 'search'];
-  var shouldRedirect = patterns.some(function(p) {
-    return path === '/' + p || path === '/' + p + '/' || path.indexOf('/' + p + '/') === 0;
-  });
-  
-  if (!shouldRedirect) {
-    return;
-  }
-  
-  if (!path.endsWith('/')) {
-    path = path + '/';
-  }
-  
-  var lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
-  var prefix = lang.indexOf('ko') === 0 ? '/ko' : '/en';
-  
-  window.location.replace(prefix + path + search + hash);
-})();
-</script>
+<script src="/js/404-redirect.js"></script>
 <noscript>
   <p style="text-align: center; margin-top: 1rem;">The page you're looking for doesn't exist.</p>
 </noscript>

--- a/static/js/404-redirect.js
+++ b/static/js/404-redirect.js
@@ -7,6 +7,7 @@
     return;
   }
   
+  // NOTE: Update this list when adding new top-level sections to the site
   var patterns = ['posts', 'about', 'tags', 'search'];
   var shouldRedirect = patterns.some(function(p) {
     return path === '/' + p || path === '/' + p + '/' || path.indexOf('/' + p + '/') === 0;

--- a/static/js/404-redirect.js
+++ b/static/js/404-redirect.js
@@ -22,6 +22,7 @@
   }
   
   var lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
+  // NOTE: Currently only ko/en supported; defaults to 'en' for all other languages
   var prefix = lang.indexOf('ko') === 0 ? '/ko' : '/en';
   
   window.location.replace(prefix + path + search + hash);

--- a/static/js/404-redirect.js
+++ b/static/js/404-redirect.js
@@ -1,0 +1,27 @@
+(function() {
+  var path = window.location.pathname;
+  var search = window.location.search;
+  var hash = window.location.hash;
+  
+  if (path.match(/^\/(ko|en)(\/|$)/)) {
+    return;
+  }
+  
+  var patterns = ['posts', 'about', 'tags', 'search'];
+  var shouldRedirect = patterns.some(function(p) {
+    return path === '/' + p || path === '/' + p + '/' || path.indexOf('/' + p + '/') === 0;
+  });
+  
+  if (!shouldRedirect) {
+    return;
+  }
+  
+  if (path.charAt(path.length - 1) !== '/') {
+    path = path + '/';
+  }
+  
+  var lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
+  var prefix = lang.indexOf('ko') === 0 ? '/ko' : '/en';
+  
+  window.location.replace(prefix + path + search + hash);
+})();


### PR DESCRIPTION
## Summary

- Add JavaScript-based redirect on 404 page to handle old URL patterns
- Redirects to `/ko/...` or `/en/...` based on browser language detection
- Preserves query strings and URL fragments
- Handles trailing slash normalization

## Problem

After adding multilingual support with `defaultContentLanguageInSubdir: true`, old URLs without language prefixes return 404 errors. External links referencing the old URL patterns need to be handled gracefully.

## Solution

Custom 404.html templates with JavaScript redirect logic that:
1. Detects if the requested URL matches an old pattern (posts, about, tags, search)
2. Detects browser language preference
3. Redirects to the appropriate language-prefixed URL

## Files Changed

- `layouts/404.html` - Hugo template for 404 pages
- `static/404.html` - Static root 404 for GitHub Pages
- `static/js/404-redirect.js` - Shared redirect logic

## Testing

- Hugo build succeeds
- Redirect script included in generated 404 pages
- ES5-compatible JavaScript (no `endsWith()`)

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 404 오류 페이지 추가: 중앙에 표시되는 명확한 메시지와 기본 메타/문서 설정 포함
  * 클라이언트 사이드 리디렉션: 브라우저 언어를 감지해 한국어(/ko) 또는 영어(/en) 버전으로 자동 연결
  * 유효 경로 검증: 특정 최상위 섹션만 리디렉션 대상으로 허용
  * JavaScript 비활성화 대응: 대체 안내 메시지 제공, 쿼리·해시 보존 및 경로 형식 보정 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->